### PR TITLE
Add support for network proxy

### DIFF
--- a/lib/utils/package-json/worker.ts
+++ b/lib/utils/package-json/worker.ts
@@ -1,11 +1,57 @@
 import type packageJson from "package-json"
 import type { Options } from "package-json"
 import { runAsWorker } from "synckit"
+// @ts-expect-error -- no types
+import tunnel from "tunnel-agent"
 type PackageJson = typeof packageJson
 
 const dynamicImport = new Function("m", "return import(m)")
 runAsWorker(async (packageName: string, options: Options) => {
     const m = await dynamicImport("package-json")
     const packageJson: PackageJson = m?.default || m
-    return packageJson(packageName, options)
+    return packageJson(packageName, withAutoProxy(options))
 })
+
+/**
+ * If users are using a proxy for their npm preferences, set the option to use that proxy.
+ */
+function withAutoProxy(options: Options): Options {
+    const PROXY_ENV = [
+        "https_proxy",
+        "HTTPS_PROXY",
+        "http_proxy",
+        "HTTP_PROXY",
+        "npm_config_https_proxy",
+        "npm_config_http_proxy",
+    ]
+
+    const proxyStr: string | undefined =
+        // eslint-disable-next-line no-process-env -- ignore
+        PROXY_ENV.map((k) => process.env[k]).find((v) => v)
+    if (proxyStr) {
+        const proxyUrl = new URL(proxyStr)
+        const tunnelOption = {
+            proxy: {
+                host: proxyUrl.hostname,
+                port: Number(proxyUrl.port),
+                proxyAuth:
+                    proxyUrl.username || proxyUrl.password
+                        ? `${proxyUrl.username}:${proxyUrl.password}`
+                        : undefined,
+            },
+        }
+        const httpAgent =
+            tunnel[`httpOverHttp${proxyUrl.protocol === "https:" ? "s" : ""}`](
+                tunnelOption,
+            )
+        const httpsAgent =
+            tunnel[`httpsOverHttp${proxyUrl.protocol === "https:" ? "s" : ""}`](
+                tunnelOption,
+            )
+        return {
+            agent: { http: httpAgent, https: httpsAgent },
+            ...options,
+        }
+    }
+    return options
+}

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "npm-package-arg": "^9.0.0",
     "package-json": "^8.1.0",
     "semver": "^7.3.5",
-    "synckit": "^0.7.1"
+    "synckit": "^0.7.1",
+    "tunnel-agent": "^0.6.0"
   }
 }


### PR DESCRIPTION
This PR modifies that if the user is using a proxy for their npm settings, that proxy will be used to get the npm information.

I can't add a test because I don't know how to test proxy in CI, but I've checked that it works fine my locally that requires proxy.