### PR TITLE
change `engines` to make the requirements more stringent

### DIFF
--- a/.changeset/many-beds-carry.md
+++ b/.changeset/many-beds-carry.md
@@ -2,4 +2,4 @@
 "eslint-plugin-node-dependencies": major
 ---
 
-chore: bump node requirement `>=18.0.0`
+chore: bump node requirement `^18.17.0 || >=20.5.0`

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.13.1",
   "description": "ESLint plugin to check Node.js dependencies.",
   "engines": {
-    "node": ">=18.0.0"
+    "node": "^18.17.0 || >=20.5.0"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -103,7 +103,7 @@
   },
   "dependencies": {
     "jsonc-eslint-parser": "^2.0.2",
-    "npm-package-arg": "^11.0.3 || ^12.0.2",
+    "npm-package-arg": "^12.0.2",
     "package-json": "^8.1.0",
     "semver": "^7.3.5",
     "synckit": "^0.11.0",


### PR DESCRIPTION
See https://github.com/ota-meshi/eslint-plugin-node-dependencies/pull/174#discussion_r2069946269