### PR TITLE
fix: add exports field for ESM compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,14 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./dist/index.js": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary

This PR adds an `exports` field to `package.json` to properly support ESM imports.

## Problem

When importing `eslint-plugin-node-dependencies` in ESM projects, the import fails with:
```
Error: Cannot find package 'eslint-plugin-node-dependencies/index.js'
Did you mean to import "eslint-plugin-node-dependencies/dist/index.js"?
```

This happens because Node.js ESM resolution requires either:
1. An explicit `exports` field in package.json
2. The exact file path in the import statement

## Solution

Added an `exports` field that properly maps:
- The main export to `./dist/index.js`
- Direct access to `./dist/index.js` for backward compatibility
- Access to `package.json` for tooling

This ensures the package works correctly in both CommonJS and ESM environments without breaking existing imports.

## Testing

The package now works correctly when imported as:
- `import * as plugin from 'eslint-plugin-node-dependencies'` (ESM)
- `const plugin = require('eslint-plugin-node-dependencies')` (CommonJS)
- `import * as plugin from 'eslint-plugin-node-dependencies/dist/index.js'` (direct path)