### PR TITLE
fix: complete the Changesets v2 action migration

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -45,11 +45,10 @@ jobs:
         uses: changesets/action@v2.0.0
         with:
           # this expects you to have a npm script called version that runs some logic and then calls `changeset version`.
-          version: npm run version:ci
+          version-script: npm run version:ci
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
-          publish: npm run release
-          commit: "chore: release eslint-plugin-node-dependencies"
-          title: "chore: release eslint-plugin-node-dependencies"
+          publish-script: npm run release
+          commit-message: "chore: release eslint-plugin-node-dependencies"
+          pr-title: "chore: release eslint-plugin-node-dependencies"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true

--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
     "undici": "^7.22.0"
   },
   "devDependencies": {
-    "@changesets/changelog-github": "^0.7.0",
-    "@changesets/cli": "^2.24.2",
+    "@changesets/changelog-github": "^1.0.0",
+    "@changesets/cli": "^3.0.0",
     "@eslint-community/eslint-utils": "^4.6.1",
     "@ota-meshi/eslint-plugin": "^0.20.0",
     "@oxc-node/core": "^0.1.0",

--- a/tools/lib/changesets-util.ts
+++ b/tools/lib/changesets-util.ts
@@ -1,6 +1,6 @@
 import assembleReleasePlan from "@changesets/assemble-release-plan";
 import readChangesets from "@changesets/read";
-import { read } from "@changesets/config";
+import { readConfig } from "@changesets/config";
 import { getPackages } from "@manypkg/get-packages";
 import { readPreState } from "@changesets/pre";
 import path from "node:path";
@@ -13,7 +13,10 @@ const root = path.resolve(dirname, "../..");
 export async function getNewVersion(): Promise<string> {
   const packages = await getPackages(root);
   const preState = await readPreState(root);
-  const config = await read(root, packages);
+  const { config, errors } = await readConfig(root, packages);
+  if (errors) {
+    throw new Error(errors.join("\n"));
+  }
   const changesets = await readChangesets(root);
 
   const releasePlan = assembleReleasePlan(
@@ -25,5 +28,5 @@ export async function getNewVersion(): Promise<string> {
 
   return releasePlan.releases.find(
     ({ name }) => name === "eslint-plugin-jsonc",
-  )!.newVersion;
+  )!.newVersion!;
 }


### PR DESCRIPTION
The release workflow began failing after `changesets/action` v2 landed because it still passed the v1 input names and installed Changesets CLI v2. This switches the workflow to v2's input names, upgrades the CLI and GitHub changelog adapter to their compatible majors, and lets the action provide its default GitHub token to the custom scripts.

Changesets v3 also replaces `@changesets/config`'s `read` API with `readConfig`, so the internal version helper now validates that result before assembling the release plan.
