### PR TITLE
chore: migrate to @eslint-community/eslint-plugin-eslint-comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "^1.0.0",
     "@changesets/cli": "^3.0.0",
+    "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
     "@eslint-community/eslint-utils": "^4.6.1",
     "@ota-meshi/eslint-plugin": "^0.20.0",
     "@oxc-node/core": "^0.1.0",
@@ -99,7 +100,6 @@
     "env-cmd": "^11.0.0",
     "eslint": "^10.0.0",
     "eslint-config-prettier": "^10.0.0",
-    "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-eslint-plugin": "^7.0.0",
     "eslint-plugin-jsdoc": "^64.0.0",
     "eslint-plugin-json-schema-validator": "^6.0.0",


### PR DESCRIPTION
Replace the unmaintained `eslint-plugin-eslint-comments` development dependency with its ESLint Community-maintained successor. Version 4.7.2 supports ESLint 10 and satisfies the peer dependency required by `@ota-meshi/eslint-plugin`.

The compatibility-rule fixtures that intentionally reference the legacy package remain unchanged.
